### PR TITLE
linum terminal friendly & keeps cocoa very similar

### DIFF
--- a/soothe-theme.el
+++ b/soothe-theme.el
@@ -326,7 +326,7 @@
 
    ;;-----------------------------------------------------------------------------------------------------------------------
    ;; Linum
-   `(linum                                     ((t (:foreground ,dirty-crem-bg :background ,alt-background :height 90   ))))
+   `(linum                                     ((t (:foreground ,gray-6 :background ,alt-background :height 90   ))))
    ;;-----------------------------------------------------------------------------------------------------------------------
    ;; show-paren-mode
    `(show-paren-match                          ((t (:foreground ,foam        :background ,orange-1                      ))))


### PR DESCRIPTION
gray-6 creates the closest look to the cocoa version. In the cocoa version it looks great too. One can barely notice the difference. The difference is that it is now terminal friendly which is how  I use emacs.
